### PR TITLE
Fix the cursor position after exiting less

### DIFF
--- a/src/mrwoo_browse.py
+++ b/src/mrwoo_browse.py
@@ -48,8 +48,9 @@ def mrwooBrowse(args):
                 site_helper = SiteHelperHandle.get(info.site)
 
                 try:
+                    print(f"{job_cnt}. [{info.status.name}] {info.title} | {info.company} | {info.url}")
+
                     while True:
-                        print(f"{job_cnt}. [{info.status.name}] {info.title} | {info.company} | {info.url}")
                         user_input = input("keep [U]nread / [Y]es to like / [N]o to dislike / [D]etails\n").lower()
                         if user_input == 'u':
                             info.status = StatusType.UNREAD

--- a/src/site_helper/base.py
+++ b/src/site_helper/base.py
@@ -213,10 +213,8 @@ class AbstractSiteHelper(ABC):
             f.flush()
 
             CMD = ["less", "-R", f.name]
-            # Move cursor to the top
-            print("\033[1024A", flush=True)
             result = subprocess.run(CMD).returncode == 0
-            print("\033[1024A", flush=True)
+
             return result
 
 


### PR DESCRIPTION
<img width="568" alt="image" src="https://user-images.githubusercontent.com/48993103/232916666-615ab0c5-c4e6-4268-95f5-a431c341611b.png">

Now can re-input after exiting less, never cover exist text in terminal again.